### PR TITLE
add support for Milk-V Duo S & Debian test target

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Example usage command
 
 ```sh
-sudo PYTHONPATH=. /home/xyz/miniconda3/envs/autotest/bin/python main.py --help
+sudo python main.py --help
 ```
 
 ```sh
@@ -53,6 +53,7 @@ options:
 - Boards (Compattibility depends on your own config) :
  1. Banana Pi BPI-F3 / SpacemiT K1
  2. StarFive VisionFive / JH7100 (flash partially supported but boot stucks on detecting block devices so testing unavailable) [Maybe a SDWireC problem]
+ 3. Milk-V Duo S
 
 ## Dependency
 

--- a/boards/milkv_duo_s_config.toml
+++ b/boards/milkv_duo_s_config.toml
@@ -1,0 +1,23 @@
+[test_framework]
+log_dir = "./logs"
+
+[board]
+board_name = "milkv_duo_s"
+
+[serial]
+serial_file = "/dev/ttyUSB0"
+bund_rate = 115200
+serial_name = "sdwirec_alpha"
+sd_mux_device = "/dev/sda"
+
+[os_list]
+[os_list.Debian]
+url = "/home/aisuneko/duos_sd.img"
+dd_params = ["bs=4M", "status=progress"]
+test_config = "./tests/debian_test.toml"
+auto_login = true
+username = "root"
+password = "rv"
+login_prompts = ["duos login:", "Username:"]
+password_prompts = ["Password:", "Secret:"]
+shell_prompt = "root@duos:~#"

--- a/tests/debian_test.toml
+++ b/tests/debian_test.toml
@@ -1,0 +1,5 @@
+tests = [
+    {name = "uname_test", command = "uname -a", expected_output = "Linux", method = "contains", timeout = 10},
+    {name = "os_release_test", command = "cat /etc/os-release", expected_output = "Debian", method = "contains", timeout = 10},
+    {name = "cpu_info_test", command = "cat /proc/cpuinfo", expected_output = "rv64i", method = "contains", timeout = 10}
+]


### PR DESCRIPTION
here's my test example:
```
(pyenv) aisuneko@Photon:~/boardtest$ python main.py -s -f -b boards/milkv_duo_s_config.toml

          Serial: sdwirec_alpha
          Board config: boards/milkv_duo_s_config.toml
          Flashing: True
          Testing: True
          Stdout log: True

==================================================
Running test suite for OS: Debian...
==================================================

Preparing to flash OS Debian...
Do you want to continue with flashing the OS image?  [y/n] (n): y
Connecting SD card to test server for OS Debian flashing...
Executing command: sudo sd-mux-ctrl --ts --device-serial=sdwirec_alpha
Connecting SD card to TS with serial sdwirec_alpha:
Connected to TS successfully.
Executing command: sudo dd if=/home/aisuneko/duos_sd.img of=/dev/sda bs=4M status=progress
Press Enter to confirm and continue...
935329792 bytes (935 MB, 892 MiB) copied, 41 s, 22.8 MB/s
223+1 records in
223+1 records out
935453184 bytes (935 MB, 892 MiB) copied, 64.4394 s, 14.5 MB/s
Connecting SD card to device under test for OS Debian...
Executing command: sudo sd-mux-ctrl --dut --device-serial=sdwirec_alpha
Connecting SD card to DUT with serial sdwirec_alpha:
Connected to DUT successfully.
Executing command: sudo sd-mux-ctrl --tick --tick-time=2000 --device-serial=sdwirec_alpha
Power cycling DUT with serial sdwirec_alpha:
Power cycle completed successfully.

Preparing to start test framework for OS Debian...
Do you want to continue with testing?  [y/n] (n): y
Starting test framework...
root
Password:
Linux duos 5.10.4-20240527-2+ #1 Sat Jun 1 14:15:39 UTC 2024 riscv64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Linux duos 5.10.4-20240527-2+ #1 Sat Jun 1 14:15:39 UTC 2024 riscv64 GNU/Linux
PRETTY_NAME="Debian GNU/Linux trixie/sid"
NAME="Debian GNU/Linux"
VERSION_CODENAME=trixie
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
processor       : 0
hart            : 0
isa             : rv64imafdvcsu
mmu             : sv39

Stopping test framework...


Test report generated: report.txt
```